### PR TITLE
No need to depend on forked geozero now that the requisite changes have been merged upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,8 +706,9 @@ dependencies = [
 
 [[package]]
 name = "geozero"
-version = "0.11.0"
-source = "git+https://github.com/georust/geozero?rev=8501fedf288adc851d08a367f8f651ee643d4bed#8501fedf288adc851d08a367f8f651ee643d4bed"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd8fb67347739a057fd607b6d8b43ba4ed93619ed84b8f429fa3296f8ae504c"
 dependencies = [
  "geo-types",
  "geojson",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,3 @@ members = [
   "geomedea_geozero",
   "geomedea-wasm"
 ]
-
-[patch.crates-io]
-# waiting for release
-geozero = { git = "https://github.com/georust/geozero", rev = "8501fedf288adc851d08a367f8f651ee643d4bed" }
-

--- a/geomedea_geozero/Cargo.toml
+++ b/geomedea_geozero/Cargo.toml
@@ -12,7 +12,7 @@ writer = ["geomedea/writer"]
 futures-util = "0.3.29"
 geomedea = { version = "0.2.0", path = "../geomedea", default-features = false }
 # Waiting for release
-geozero = '*'
+geozero = '0.13.0'
 log = "0.4.20"
 
 [dev-dependencies]


### PR DESCRIPTION
Note you still need to use my fork of geozero-cli to use geomedea with
the geozero cli.
