### PR TITLE
stream feature locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-http-range-client"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66ff5fba23ab8761b13d09408a99a1de5699bafa10725549031f642dda5f37d"
+checksum = "c36485450d6c5dce07e80f19435ceab2c8c581f58582cf38f0f0d93f9efd585d"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/geomedea/Cargo.toml
+++ b/geomedea/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 tempfile = "3.8.0"
 thiserror = "1.0.49"
 zstd = {  version = "0.12.4", optional = true }
-streaming-http-range-client = { version = "1.0.0" }
+streaming-http-range-client = { version = "1.0.1" }
 futures-util = { version = "0.3.29", default-features = false }
 tokio = { version = "1.34.0", default-features = false }
 async-stream = "0.3.5"

--- a/geomedea/src/format.rs
+++ b/geomedea/src/format.rs
@@ -16,8 +16,10 @@ pub(crate) struct PageHeader {
     encoded_page_length: u32,
 
     /// The number of bytes after decompression. This is the number of bytes that will be
-    /// read from the page to decode the features.k
+    /// read from the page to decode the features.
     decoded_page_length: u32,
+
+    /// How many features are in this page.
     feature_count: u32,
 }
 

--- a/geomedea/src/packed_r_tree/mod.rs
+++ b/geomedea/src/packed_r_tree/mod.rs
@@ -54,6 +54,7 @@ impl Node {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PackedRTree {
     num_leaf_nodes: u64,
     node_ranges_by_level: OnceCell<Vec<Range<u64>>>,

--- a/geomedea/src/writer/mod.rs
+++ b/geomedea/src/writer/mod.rs
@@ -26,6 +26,10 @@ pub struct Writer<W: Write> {
     page_size_goal: u64,
 }
 
+// How large should we make each page of feature data
+// before starting a new page.
+const DEFAULT_PAGE_SIZE_GOAL: u64 = 1024 * 64;
+
 impl<W: Write> Writer<W> {
     pub fn new(inner: W, is_compressed: bool) -> Result<Self> {
         let header = Header {
@@ -39,7 +43,7 @@ impl<W: Write> Writer<W> {
             feature_entries: vec![],
             extent: Bounds::empty(),
             header,
-            page_size_goal: 1024 * 64, // REVIEW: what should default limit be?
+            page_size_goal: DEFAULT_PAGE_SIZE_GOAL,
         })
     }
 


### PR DESCRIPTION
This allows the client to start fetching FeatureData a little bit sooner.

TBH the measurable impact is pretty minimal in the browser, but I do see a little parallelism.

![image](https://github.com/user-attachments/assets/34b4b7cc-0c4b-4d30-a38d-1138d4d77f15)

Before, on the left, you can see we don't fetch any Feature data until all the index traversal is complete.

On the right, you can see we start fetching Feature data a little earlier, before completing index traversal. Particularly interesting are those last two index traversal requests, which I think indicate dead end nodes - that is, nodes whose bounding boxes intersects ours, but who don't actually have any nodes in our bbox.