### PR TITLE
batch feature locations

### DIFF
--- a/geomedea/src/lib.rs
+++ b/geomedea/src/lib.rs
@@ -39,6 +39,10 @@ use tokio::io as asyncio;
 pub use crate::feature::{Feature, Properties, PropertyValue};
 use serde::{Deserialize, Serialize};
 
+// How large should we make each page of feature data
+// before starting a new page.
+pub(crate) const DEFAULT_PAGE_SIZE_GOAL: u64 = 1024 * 64;
+
 pub(crate) fn serialized_size<T>(value: &T) -> Result<u64>
 where
     T: serde::Serialize + ?Sized,

--- a/geomedea/src/writer/mod.rs
+++ b/geomedea/src/writer/mod.rs
@@ -4,7 +4,7 @@ use crate::io::CountingWriter;
 use crate::packed_r_tree::{Node, PackedRTreeWriter};
 use crate::{
     deserialize_from, serialize_into, serialized_size, Feature, FeatureLocation, Header,
-    PageHeader, Result,
+    PageHeader, Result, DEFAULT_PAGE_SIZE_GOAL,
 };
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::fs::File;
@@ -25,10 +25,6 @@ pub struct Writer<W: Write> {
     /// after this limit is hit, so pages will be slightly larger than this size.
     page_size_goal: u64,
 }
-
-// How large should we make each page of feature data
-// before starting a new page.
-const DEFAULT_PAGE_SIZE_GOAL: u64 = 1024 * 64;
 
 impl<W: Write> Writer<W> {
     pub fn new(inner: W, is_compressed: bool) -> Result<Self> {


### PR DESCRIPTION
We now make an educated guess as to how much "overfetch" to do based on the proximity of subsequent Features.

It's just a guess because we don't know how large the Feature's page actually is until we fetch the page's header.

![image](https://github.com/user-attachments/assets/13807a5a-98c2-4bbc-8f4b-06bba33d358c)

The initial load of https://michaelkirk.github.io/geomedea/examples/maplibre/large.html goes down from 1.1MB to 312kb.

Now if I could just get the damn wasm file to be smaller 😅 
<img width="1173" alt="Screenshot 2024-07-18 at 15 49 33" src="https://github.com/user-attachments/assets/20f918b7-cd4c-42e2-9d56-e9be7aa08b43">
